### PR TITLE
v1.0.1 - Fix weighted pressure plate multi-triggering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Parkour
 
+[![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.jcx.ovh%2Fjob%2FDumbDogDiner%2Fjob%2Fparkour%2Fjob%2Fstable%2F&label=jenkins%20%7C%20stable&logo=jenkins&logoColor=white)](https://ci.jcx.ovh/job/DumbDogDiner/job/parkour/job/stable/)
+[![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.jcx.ovh%2Fjob%2FDumbDogDiner%2Fjob%2Fparkour%2Fjob%2Fdev%2F&label=jenkins%20%7C%20dev&logo=jenkins&logoColor=white)](https://ci.jcx.ovh/job/DumbDogDiner/job/parkour/job/dev/)
+
 Parkour plugin for the DDD lobby server.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -3,18 +3,33 @@
 [![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.jcx.ovh%2Fjob%2FDumbDogDiner%2Fjob%2Fparkour%2Fjob%2Fstable%2F&label=jenkins%20%7C%20stable&logo=jenkins&logoColor=white)](https://ci.jcx.ovh/job/DumbDogDiner/job/parkour/job/stable/)
 [![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.jcx.ovh%2Fjob%2FDumbDogDiner%2Fjob%2Fparkour%2Fjob%2Fdev%2F&label=jenkins%20%7C%20dev&logo=jenkins&logoColor=white)](https://ci.jcx.ovh/job/DumbDogDiner/job/parkour/job/dev/)
 
-Parkour plugin for the DDD lobby server.
+Interactive Minecraft Parkour plugin with a personality.
+
+## Features
+- Course Editor - create courses by using the `/pk create <name>` command, and use the editor to add checkpoints to the course. Once finished, drop the editor, and the course will be finalized.
+- Personal bests & server records - once players complete the course for the first time, they will set a personal best. Beating this, and the overall server best, displays special messages in chat.
 
 ## Commands
+**Requires:** `default`
+`/pk quit` - stop the current parkour session (both physical and the editor).
 
-- `parkour create` - enter the course creator, allowing you to add checkpoints to a new course
+**Requires:** `parkour.command`
+`/pk create <name>` - create a new course with the editor.
+`/pk delete <name>` - delete the named course.
+`/pk list` - list all available courses.
 
-## Configuration
+## Placeholders
+Parkour has a few placeholders for use with PlaceholderAPI.
 
-- `language` - allows the control of the plugin's response language & formatting.
-- `courses` - manual modification of parkour courses (would not recommend it's horrible).
+- `parkour_course_<name>_record` - the fastest time this course has been completed in. Given in seconds.
+- `parkour_course_<name>_personal_best` - the fastest time the executing player has completed this course in. Given in seconds.
+- `parkour_course_<name>_checkpoint_count` - the number of checkpoints in this course.
 
-## Todo
-
-- Finish editor
-- Fix drop listener
+## Next Steps
+- Bounding boxes - areas which reset players back to the previous checkpoint if they leave without passing the next checkpoint.
+- Parkour tools - controls with which players can jump back to previous checkpoints, or the start of the course.
+- Effect pads - grant players who step on them potion effects for a wider variety of possible courses.
+- Jump pads - launch players who step on them into the air, controllable with a sexy editor owo~
+- Vault integration - allow the giving of currency via vault when players step on checkpoints and complete courses.
+- Coins - balls of particles that act as goals that players obtain in exchange for currency.
+- Par Times - configuration of the maximum time of completion before rewards begin to fall off.

--- a/src/main/kotlin/com/dumbdogdiner/parkour/ParkourPlugin.kt
+++ b/src/main/kotlin/com/dumbdogdiner/parkour/ParkourPlugin.kt
@@ -28,8 +28,11 @@ class ParkourPlugin : JavaPlugin() {
 
         // events events events
         server.pluginManager.registerEvents(PlayerSessionListener(), this)
+        server.pluginManager.registerEvents(PlayerEditorSessionListener(), this)
+
         server.pluginManager.registerEvents(PlayerMiscListener(), this)
         server.pluginManager.registerEvents(PlayerQuitListener(), this)
+
         server.pluginManager.registerEvents(WorldListener(), this)
 
         // Register PAPI expansion if available.

--- a/src/main/kotlin/com/dumbdogdiner/parkour/courses/CourseStorage.kt
+++ b/src/main/kotlin/com/dumbdogdiner/parkour/courses/CourseStorage.kt
@@ -73,7 +73,7 @@ class CourseStorage : Base {
         val res = mutableListOf<Location>()
 
         for (checkpoint in section.getStringList("checkpoints")) {
-            val loc = deserializeLocation(checkpoint) ?: return null
+            val loc = Utils.deserializeLocation(checkpoint) ?: return null
             res.add(loc)
         }
 
@@ -101,7 +101,7 @@ class CourseStorage : Base {
 
         section.set("name", course.name)
         section.set("description", course.description)
-        section.set("checkpoints", course.getCheckpoints().map { serializeLocation(it) })
+        section.set("checkpoints", course.getCheckpoints().map { Utils.serializeLocation(it) })
 
         if (skipSave) {
             return
@@ -118,25 +118,4 @@ class CourseStorage : Base {
         Utils.log("Deleted course '${course.id}' from disk.")
     }
 
-    companion object : Base {
-        fun serializeLocation(loc: Location): String {
-            return "${loc.world.name}:${loc.x}:${loc.y}:${loc.z}"
-        }
-        fun deserializeLocation(raw: String): Location? {
-            val delimited = raw.split(":")
-
-            if (delimited.size != 4) {
-                logger.warning("Failed to deserilize location '$raw' - invalid length.")
-                return null
-            }
-
-            val world = Bukkit.getWorld(delimited[0])
-            if (world == null) {
-                logger.warning("Failed to deserilize location '$raw' - world '${delimited[0]}' does not exist.")
-                return null
-            }
-
-            return Location(world, delimited[1].toDouble(), delimited[2].toDouble(), delimited[3].toDouble())
-        }
-    }
 }

--- a/src/main/kotlin/com/dumbdogdiner/parkour/listeners/PlayerEditorSessionListener.kt
+++ b/src/main/kotlin/com/dumbdogdiner/parkour/listeners/PlayerEditorSessionListener.kt
@@ -1,0 +1,37 @@
+package com.dumbdogdiner.parkour.listeners
+
+import com.dumbdogdiner.parkour.Base
+
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.block.Action
+import org.bukkit.event.player.PlayerDropItemEvent
+import org.bukkit.event.player.PlayerInteractEvent
+
+/**
+ * Listener for events related to editing sessions.
+ */
+class PlayerEditorSessionListener : Listener, Base {
+    /**
+     * Handle a checkpoint being clicked during an editing session.
+     */
+    @EventHandler
+    private fun handleCheckpointClicked(e: PlayerInteractEvent) {
+        val block = e.clickedBlock
+        if (e.action != Action.RIGHT_CLICK_BLOCK || block == null) { return }
+
+        val session = editingSessionManager.getEditingSession(e.player) ?: return
+
+        session.handleCheckpointClicked(e)
+    }
+
+    /**
+     * Handle the player dropping the editor tool.
+     */
+    @EventHandler
+    fun onPlayerItemDrop(e: PlayerDropItemEvent) {
+        if (editingSessionManager.isPlayerInEditingSession(e.player)) {
+            editingSessionManager.getEditingSession(e.player)?.handleDropEvent(e)
+        }
+    }
+}

--- a/src/main/kotlin/com/dumbdogdiner/parkour/listeners/PlayerQuitListener.kt
+++ b/src/main/kotlin/com/dumbdogdiner/parkour/listeners/PlayerQuitListener.kt
@@ -6,13 +6,19 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerQuitEvent
 
+/**
+ * Handle a player leaving the server during a parkour session.
+ */
 class PlayerQuitListener : Listener, Base {
     @EventHandler
-    fun onJoin(e: PlayerQuitEvent) {
+    fun onPlayerQuit(e: PlayerQuitEvent) {
         if (plugin.sessionManager.isPlayerInSession(e.player)) {
-            plugin.sessionManager.endSession(e.player, false)
+            // Dont allow players to store records by leaving sessions.
+            plugin.sessionManager.endSession(e.player, returnToStart = false, escapeRecord = true)
         } else if (plugin.editingSessionManager.isPlayerInEditingSession((e.player))) {
-            plugin.editingSessionManager.endEditingSession(e.player)
+            // Drop editing progress on player quit.
+            // TODO: This might be annoying.
+            plugin.editingSessionManager.endEditingSession(e.player, dropProgress = true)
         }
     }
 }

--- a/src/main/kotlin/com/dumbdogdiner/parkour/listeners/PlayerSessionListener.kt
+++ b/src/main/kotlin/com/dumbdogdiner/parkour/listeners/PlayerSessionListener.kt
@@ -2,91 +2,32 @@ package com.dumbdogdiner.parkour.listeners
 
 import com.dumbdogdiner.parkour.Base
 import com.dumbdogdiner.parkour.utils.Utils
+import org.bukkit.Location
 
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.Action
+import org.bukkit.event.block.BlockRedstoneEvent
 import org.bukkit.event.player.PlayerDropItemEvent
 import org.bukkit.event.player.PlayerInteractEvent
 
 class PlayerSessionListener : Listener, Base {
-
-    /**
-     * Listens for player interaction events e.g. stepping on pressure plates, right-clicking with tools.
-     */
-    @EventHandler
-    fun onPlayerInteract(e: PlayerInteractEvent) {
-        if (handleNextCheckpoint(e)) {
-            return
-        }
-
-        if (handleCheckpointClicked(e)) {
-            return
-        }
-
-        if (handleClickWithControls(e)) {
-            return
-        }
-    }
-    /**
-     * Prevent players from dropping editor tools, or session controls.
-     */
-
-    @EventHandler
-    fun onPlayerItemDrop(e: PlayerDropItemEvent) {
-        if (sessionManager.isPlayerInSession(e.player)) {
-            sessionManager.getSession(e.player)?.handleDropEvent(e)
-        } else if (editingSessionManager.isPlayerInEditingSession(e.player)) {
-            editingSessionManager.getEditingSession(e.player)?.handleDropEvent(e)
-        }
-    }
-
-
     /**
      * Handle a player stepping on a pressure plate while they are in a parkour session.
      */
-    private fun handleNextCheckpoint(e: PlayerInteractEvent): Boolean {
-        val block = e.clickedBlock
-        if (e.action != Action.PHYSICAL || block == null || !Utils.isPressurePlate(block.type)) { return false }
-
-        // If the player isn't in a session, and respective block is the first checkpoint
-        val course = plugin.courseManager.findCourseFromStart(block.location)
-        if (course != null && !plugin.sessionManager.isPlayerInSession(e.player)) {
-            plugin.sessionManager.createSession(e.player, course)
-            return true
-        }
-
-        // If the player is in a session
-        val session = plugin.sessionManager.getSession(e.player) ?: return false
-        session.handleCheckpoint(e)
-
-        return true
+    @EventHandler
+    fun onHandleCheckpoint(e: PlayerInteractEvent) {
+        val block = e.clickedBlock ?: return
+        if (e.action != Action.PHYSICAL || !Utils.isPressurePlate(block.type)) { return }
+        sessionManager.handleCheckpointInteraction(e)
     }
 
     /**
-     * Handle a checkpoint being clicked during an editing session.
+     * Listen for redstone events on pressure plates.
      */
-    private fun handleCheckpointClicked(e: PlayerInteractEvent): Boolean {
-        val block = e.clickedBlock
-        if (e.action != Action.RIGHT_CLICK_BLOCK || block == null) { return false }
-
-        val session = editingSessionManager.getEditingSession(e.player) ?: return false
-
-        session.handleCheckpointClicked(e)
-        return true
-    }
-
-    /**
-     * Handle a player clicking with the parkour controls.
-     */
-    private fun handleClickWithControls(e: PlayerInteractEvent): Boolean {
-        if (e.action != Action.RIGHT_CLICK_BLOCK || e.action != Action.RIGHT_CLICK_AIR || !e.hasItem()) {
-            return false
-        }
-
-        val session = plugin.sessionManager.getSession(e.player) ?: return false
-        session.handleCheckpoint(e)
-
-        return true
+    @EventHandler
+    fun onHandleCheckpointRedstoneUpdate(e: BlockRedstoneEvent) {
+        if (!Utils.isPressurePlate(e.block.type)) { return }
+        sessionManager.handleCheckpointRedstoneUpdate(e)
     }
 }

--- a/src/main/kotlin/com/dumbdogdiner/parkour/session/Session.kt
+++ b/src/main/kotlin/com/dumbdogdiner/parkour/session/Session.kt
@@ -24,6 +24,8 @@ class Session(val player: Player, val course: Course) : Base {
 
     private val timer = TimerUtils.createTimer(player)
 
+    private var firstCheckpointSteppedOn = System.currentTimeMillis()
+
     init {
         /* TODO: Properly implement this.
         player.inventory.addItem(returnItem.clone())
@@ -80,7 +82,16 @@ class Session(val player: Player, val course: Course) : Base {
         val block = e.clickedBlock ?: return
 
         if (course.getCheckpoints().first() == block.location) {
-            player.sendMessage(Language.startCourse)
+            // Add a delay to prevent people from spamming the first checkpoint.
+            val steppedOn = firstCheckpointSteppedOn
+            firstCheckpointSteppedOn = System.currentTimeMillis()
+
+            if (System.currentTimeMillis() - steppedOn < 500) {
+                return
+            }
+
+
+            player.sendMessage(Language.restartCourse.replace("%COURSE%", course.name, ignoreCase = true))
             SoundUtils.info(player)
             timer.reset()
             return

--- a/src/main/kotlin/com/dumbdogdiner/parkour/utils/Configuration.kt
+++ b/src/main/kotlin/com/dumbdogdiner/parkour/utils/Configuration.kt
@@ -32,6 +32,7 @@ object Configuration {
         config.addDefault(path + "startCourse", "&bCourse &a'%COURSE%' &bstarted!")
         config.addDefault(path + "finishCourse", "&bYou finished the course &a'%COURSE%' &b- awesome!")
         config.addDefault(path + "nextCheckpoint", "&e&lCheckpoint &r&bpassed!")
+        config.addDefault(path + "restartCourse", "&bTimer restarted!")
         config.addDefault(path + "newRecord", "&d&lRECORD&b - &c%TIME%s &bon &a'%COURSE%' &bby &c%PLAYER%")
         config.addDefault(path + "exitSession", "&bExited the current session.")
 

--- a/src/main/kotlin/com/dumbdogdiner/parkour/utils/Language.kt
+++ b/src/main/kotlin/com/dumbdogdiner/parkour/utils/Language.kt
@@ -31,6 +31,8 @@ object Language {
         get() = "$prefix${get("$path.finishCourse")}"
     val nextCheckpoint
         get() = "$prefix${get("$path.nextCheckpoint")}"
+    val restartCourse
+        get() = "$prefix${get("$path.restartCourse")}"
     val newRecord
         get() = "$prefix${get("$path.newRecord")}"
     val exitSession

--- a/src/main/kotlin/com/dumbdogdiner/parkour/utils/Utils.kt
+++ b/src/main/kotlin/com/dumbdogdiner/parkour/utils/Utils.kt
@@ -1,5 +1,6 @@
 package com.dumbdogdiner.parkour.utils
 
+import com.dumbdogdiner.parkour.courses.CourseStorage
 import org.bukkit.*
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
@@ -63,4 +64,33 @@ object Utils {
         }
         return kotlin.math.round(v * multiplier) / multiplier
     }
+
+    /**
+     * Serialize a location into  astring.
+     */
+    fun serializeLocation(loc: Location): String {
+        return "${loc.world.name}:${loc.x}:${loc.y}:${loc.z}"
+    }
+
+    /**
+     * Deserialize a string into a location.
+     */
+    fun deserializeLocation(raw: String): Location? {
+        val delimited = raw.split(":")
+
+        if (delimited.size != 4) {
+            log("Failed to deserilize location '$raw' - invalid length.")
+            return null
+        }
+
+        val world = Bukkit.getWorld(delimited[0])
+        if (world == null) {
+           log("Failed to deserilize location '$raw' - world '${delimited[0]}' does not exist.")
+            return null
+        }
+
+        return Location(world, delimited[1].toDouble(), delimited[2].toDouble(), delimited[3].toDouble())
+    }
+
 }
+


### PR DESCRIPTION
# v1.0.1

This patch introduces some fixes for a couple of bugs.

## Fixes
- Switched to using combined `PlayerInteractEvent` and `BlockRedstone` event to detect when a pressure plate changes state due to a player
- Patched some missing string interpolations

## Changes
- Lowered the pitch of the error bass from F#, like every other sound, to F, just to see if Stixil notices the dissonance ;3
- Updated README.md to be hot and sexy~
- Removed Vlad